### PR TITLE
Add EditorConfig support for project-specific indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,10 @@ If you want to disable copilot by default - use
 | `␣mn`   | Jump to next mark in local buffer           |
 | `␣mp`   | Jump to previous mark in local buffer       |
 
+### [editorconfig-vim](https://github.com/editorconfig/editorconfig-vim) EditorConfig support
+
+Automatically applies project-specific indentation and formatting settings from `.editorconfig` files.
+
 # TIPS to remember
 
 - `Ctrl-v` | vertical edit mode. CONFLICTS WITH SYSTEM PASTE ON WINDOWS

--- a/lua/constantinchik/plugins/editorconfig.lua
+++ b/lua/constantinchik/plugins/editorconfig.lua
@@ -1,0 +1,4 @@
+return {
+  "editorconfig/editorconfig-vim",
+  event = { "BufReadPre", "BufNewFile" },
+}


### PR DESCRIPTION
## Summary
- Adds editorconfig-vim plugin for automatic project-specific settings
- Updates README with EditorConfig documentation
- Enables consistent indentation across different projects without manual configuration

## Test plan
- [x] Install editorconfig-vim plugin
- [x] Create .editorconfig file in test project
- [x] Verify indentation settings are applied automatically
- [x] Update documentation

🤖 Generated with [Claude Code](https://claude.ai/code)